### PR TITLE
パッケージの使い方の最新へのアップデートとPrisma 6.18.0への対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,18 @@ ut.code(); Learnに準拠したサンプルプロジェクトです。
    $ mkdir backend
    $ cd backend
    $ npm init
-   $ npm install express cors
-   $ npm install -D typescript tsx @types/express @types/cors
+   $ npm install express @prisma/client dotenv cors
+   $ npm install -D typescript tsx @types/express prisma @types/cors
    $ npx tsc --init
    $ npx prisma init
    ```
 
 1. `/frontend/.env`を作成して、`VITE_API_ENDPOINT`を`http://localhost:3000`に設定する
+1. `/backend/package.json`で`type`フィールドを`module`に設定する
 1. `/backend/.env`で`WEB_ORIGIN`を`http://localhost:5173`に設定し、`DATABASE_URL`も設定する
+1. `/backend/prisma.config.ts`に`import "dotenv/config";`を追加して、`.env`の内容が読み込まれるようにする
 1. `/backend/prisma/schema.prisma`の内容をデータベースに反映させるために`npx prisma db push`を実行する
 1. `/backend/tsconfig.json`の`outDir`オプションを`./dist`にしてトランスパイル結果が`/backend/dist`に入るようにする
-1. `/backend/tsconfig.json`の`declaration`オプションと`declarationMap`オプションを消し`allowJs`オプションを`true`にしてPrismaが生成したJavaScriptファイルをトランスパイル結果に含めるようにする
 1. `/backend/dist`を`/backend/.gitignore`に追加する
 1. `/backend/package.json`を変更して次のコマンドが使えるようにする
    - `npm run dev`：`tsx`を使ってトランスパイル前のTypeScriptを直接実行する（開発環境用）

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import cors from "cors";
-import { PrismaClient } from "./generated/prisma/index.js";
+import { PrismaClient } from "./generated/prisma/client.js";
 
 const app = express();
 const client = new PrismaClient();

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6,14 +6,15 @@
     "": {
       "name": "backend",
       "dependencies": {
-        "@prisma/client": "^6.17.1",
+        "@prisma/client": "^6.18.0",
         "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
         "express": "^5.1.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
-        "prisma": "^6.17.1",
+        "prisma": "^6.18.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
       }
@@ -461,9 +462,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.17.1.tgz",
-      "integrity": "sha512-zL58jbLzYamjnNnmNA51IOZdbk5ci03KviXCuB0Tydc9btH2kDWsi1pQm2VecviRTM7jGia0OPPkgpGnT3nKvw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.18.0.tgz",
+      "integrity": "sha512-jnL2I9gDnPnw4A+4h5SuNn8Gc+1mL1Z79U/3I9eE2gbxJG1oSA+62ByPW4xkeDgwE0fqMzzpAZ7IHxYnLZ4iQA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -483,66 +484,66 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.17.1.tgz",
-      "integrity": "sha512-fs8wY6DsvOCzuiyWVckrVs1LOcbY4LZNz8ki4uUIQ28jCCzojTGqdLhN2Jl5lDnC1yI8/gNIKpsWDM8pLhOdwA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.18.0.tgz",
+      "integrity": "sha512-rgFzspCpwsE+q3OF/xkp0fI2SJ3PfNe9LLMmuSVbAZ4nN66WfBiKqJKo/hLz3ysxiPQZf8h1SMf2ilqPMeWATQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.16.12",
+        "effect": "3.18.4",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.17.1.tgz",
-      "integrity": "sha512-Vf7Tt5Wh9XcndpbmeotuqOMLWPTjEKCsgojxXP2oxE1/xYe7PtnP76hsouG9vis6fctX+TxgmwxTuYi/+xc7dQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.18.0.tgz",
+      "integrity": "sha512-PMVPMmxPj0ps1VY75DIrT430MoOyQx9hmm174k6cmLZpcI95rAPXOQ+pp8ANQkJtNyLVDxnxVJ0QLbrm/ViBcg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.17.1.tgz",
-      "integrity": "sha512-D95Ik3GYZkqZ8lSR4EyFOJ/tR33FcYRP8kK61o+WMsyD10UfJwd7+YielflHfKwiGodcqKqoraWw8ElAgMDbPw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.18.0.tgz",
+      "integrity": "sha512-i5RzjGF/ex6AFgqEe2o1IW8iIxJGYVQJVRau13kHPYEL1Ck8Zvwuzamqed/1iIljs5C7L+Opiz5TzSsUebkriA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.17.1",
-        "@prisma/engines-version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
-        "@prisma/fetch-engine": "6.17.1",
-        "@prisma/get-platform": "6.17.1"
+        "@prisma/debug": "6.18.0",
+        "@prisma/engines-version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
+        "@prisma/fetch-engine": "6.18.0",
+        "@prisma/get-platform": "6.18.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac.tgz",
-      "integrity": "sha512-17140E3huOuD9lMdJ9+SF/juOf3WR3sTJMVyyenzqUPbuH+89nPhSWcrY+Mf7tmSs6HvaO+7S+HkELinn6bhdg==",
+      "version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f.tgz",
+      "integrity": "sha512-T7Af4QsJQnSgWN1zBbX+Cha5t4qjHRxoeoWpK4JugJzG/ipmmDMY5S+O0N1ET6sCBNVkf6lz+Y+ZNO9+wFU8pQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.17.1.tgz",
-      "integrity": "sha512-AYZiHOs184qkDMiTeshyJCtyL4yERkjfTkJiSJdYuSfc24m94lTNL5+GFinZ6vVz+ktX4NJzHKn1zIFzGTWrWg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.18.0.tgz",
+      "integrity": "sha512-TdaBvTtBwP3IoqVYoGIYpD4mWlk0pJpjTJjir/xLeNWlwog7Sl3bD2J0jJ8+5+q/6RBg+acb9drsv5W6lqae7A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.17.1",
-        "@prisma/engines-version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
-        "@prisma/get-platform": "6.17.1"
+        "@prisma/debug": "6.18.0",
+        "@prisma/engines-version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
+        "@prisma/get-platform": "6.18.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.17.1.tgz",
-      "integrity": "sha512-AKEn6fsfz0r482S5KRDFlIGEaq9wLNcgalD1adL+fPcFFblIKs1sD81kY/utrHdqKuVC6E1XSRpegDK3ZLL4Qg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.18.0.tgz",
+      "integrity": "sha512-uXNJCJGhxTCXo2B25Ta91Rk1/Nmlqg9p7G9GKh8TPhxvAyXCvMNQoogj4JLEUy+3ku8g59cpyQIKFhqY2xO2bg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.17.1"
+        "@prisma/debug": "6.18.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -584,15 +585,15 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.5.tgz",
+      "integrity": "sha512-LuIQOcb6UmnF7C1PCFmEU1u2hmiHL43fgFQX67sN3H4Z+0Yk0Neo++mFsBjhOAuLzvlQeqAAkeDOZrJs9rzumQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
@@ -647,9 +648,9 @@
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -657,9 +658,9 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
-      "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,9 +670,9 @@
       }
     },
     "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -748,6 +749,19 @@
         "magicast": {
           "optional": true
         }
+      }
+    },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -925,10 +939,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -958,9 +971,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
-      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1243,9 +1256,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
-      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1565,15 +1578,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.17.1.tgz",
-      "integrity": "sha512-ac6h0sM1Tg3zu8NInY+qhP/S9KhENVaw9n1BrGKQVFu05JT5yT5Qqqmb8tMRIE3ZXvVj4xcRA5yfrsy4X7Yy5g==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.18.0.tgz",
+      "integrity": "sha512-bXWy3vTk8mnRmT+SLyZBQoC2vtV9Z8u7OHvEu+aULYxwiop/CPiFZ+F56KsNRNf35jw+8wcu8pmLsjxpBxAO9g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.17.1",
-        "@prisma/engines": "6.17.1"
+        "@prisma/config": "6.18.0",
+        "@prisma/engines": "6.18.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,19 +1,21 @@
 {
   "name": "backend",
+  "type": "module",
   "scripts": {
-    "dev": "tsx main.mts",
+    "dev": "tsx --env-file=.env main.ts",
     "build": "prisma generate && tsc",
-    "start": "node dist/main.mjs"
+    "start": "node --env-file=.env dist/main.js"
   },
   "dependencies": {
-    "@prisma/client": "^6.17.1",
+    "@prisma/client": "^6.18.0",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
-    "prisma": "^6.17.1",
+    "prisma": "^6.18.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,0 +1,13 @@
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  engine: "classic",
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,7 +5,7 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
   output   = "../generated/prisma"
 }
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -17,9 +17,8 @@
 
     // Other Outputs
     "sourceMap": true,
-    // "declaration": true,
-    // "declarationMap": true,
-    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
 
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
すべてのパッケージをアップデートし、Prisma 6.18.0に対応しました。

- 以前は`prisma db push`の際に自動で`prisma`と`@prisma/client`がインストールされていましたが、Prisma 6.18.0以降は事前にこれらをインストールしておく必要があるようになったようです。
- Prisma 6.18.0以降、`prisma init`をした際に生成されるファイルで`prisma.config.ts`が使用されるようになりました。cf. https://www.prisma.io/blog/announcing-prisma-6-18-0#init-with-prismaconfigts-automatically
- Prisma 6.18.0以降、`prisma init`をした際に生成されるファイルでは、`prisma-client-js`generatorではなく`prisma-client`generatorが使用されるようになったようです。
- `prisma-client`generatorを使用することで、`.env`ファイルが自動で読み込まれなくなりました。（cf. https://www.prisma.io/docs/orm/prisma-schema/overview/generators#prisma-client ）TypeScriptファイルやJavaScriptファイルを実行する際には、`--env-file=.env`などによって`.env`ファイルを読み込む必要があります。（cf. https://www.prisma.io/docs/orm/reference/prisma-config-reference#using-environment-variables ）`prisma db push`をする際などのために、`prisma.config.ts`内で`dotenv`を使用する必要があるのではないかと考えられます。
- `prisma-client`generatorでは、`prisma generate`をした際にTypeScriptファイルが生成されるため、`tsconfig.json`で`allowJs`オプションを`true`にする必要がなくなりました。 cf. https://www.prisma.io/docs/orm/prisma-schema/overview/generators#prisma-client
- `prisma-client`generatorを使用することで、Prisma Clientのインポート方法が変わりました。 cf. https://www.prisma.io/docs/orm/prisma-schema/overview/generators#importing-prisma-client
- 生成される`prisma.config.ts`ファイルの拡張子が`.ts`であり動かすには、拡張子を`.mts`にする必要が出てきたため、`package.json`の`type`フィールドを`module`にしました。